### PR TITLE
Add authentication with Google and email

### DIFF
--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -14,6 +14,15 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'django.contrib.sites',
+    'rest_framework',
+    'rest_framework.authtoken',
+    'dj_rest_auth',
+    'dj_rest_auth.registration',
+    'allauth',
+    'allauth.account',
+    'allauth.socialaccount',
+    'allauth.socialaccount.providers.google',
 ]
 
 MIDDLEWARE = [
@@ -67,3 +76,24 @@ USE_TZ = True
 
 STATIC_URL = 'static/'
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
+
+SITE_ID = 1
+
+REST_USE_JWT = True
+
+REST_FRAMEWORK = {
+    'DEFAULT_AUTHENTICATION_CLASSES': (
+        'rest_framework_simplejwt.authentication.JWTAuthentication',
+    )
+}
+
+ACCOUNT_EMAIL_VERIFICATION = 'none'
+ACCOUNT_AUTHENTICATION_METHOD = 'email'
+ACCOUNT_EMAIL_REQUIRED = True
+
+SOCIALACCOUNT_PROVIDERS = {
+    'google': {
+        'SCOPE': ['profile', 'email'],
+        'AUTH_PARAMS': {'access_type': 'online'},
+    }
+}

--- a/backend/backend/urls.py
+++ b/backend/backend/urls.py
@@ -1,6 +1,10 @@
 from django.contrib import admin
-from django.urls import path
+from django.urls import path, include
+from .views import GoogleLogin
 
 urlpatterns = [
     path('admin/', admin.site.urls),
+    path('api/auth/', include('dj_rest_auth.urls')),
+    path('api/auth/registration/', include('dj_rest_auth.registration.urls')),
+    path('api/auth/google/', GoogleLogin.as_view(), name='google_login'),
 ]

--- a/backend/backend/views.py
+++ b/backend/backend/views.py
@@ -1,0 +1,6 @@
+from dj_rest_auth.registration.views import SocialLoginView
+from allauth.socialaccount.providers.google.views import GoogleOAuth2Adapter
+
+
+class GoogleLogin(SocialLoginView):
+    adapter_class = GoogleOAuth2Adapter

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,1 +1,5 @@
 Django>=4.2
+djangorestframework
+djangorestframework-simplejwt
+dj-rest-auth
+django-allauth

--- a/frontend/lib/login_page.dart
+++ b/frontend/lib/login_page.dart
@@ -1,0 +1,79 @@
+import 'dart:convert';
+import 'package:flutter/material.dart';
+import 'package:http/http.dart' as http;
+import 'package:google_sign_in/google_sign_in.dart';
+
+class LoginPage extends StatefulWidget {
+  const LoginPage({Key? key}) : super(key: key);
+
+  @override
+  State<LoginPage> createState() => _LoginPageState();
+}
+
+class _LoginPageState extends State<LoginPage> {
+  final TextEditingController _emailController = TextEditingController();
+  final TextEditingController _passwordController = TextEditingController();
+  final GoogleSignIn _googleSignIn = GoogleSignIn(scopes: ['email']);
+
+  Future<void> _login() async {
+    final response = await http.post(
+      Uri.parse('http://localhost:8000/api/auth/login/'),
+      body: {
+        'email': _emailController.text,
+        'password': _passwordController.text,
+      },
+    );
+    if (response.statusCode == 200) {
+      // Handle success, e.g. save token
+    }
+  }
+
+  Future<void> _googleLogin() async {
+    final account = await _googleSignIn.signIn();
+    if (account == null) return;
+    final auth = await account.authentication;
+    final response = await http.post(
+      Uri.parse('http://localhost:8000/api/auth/google/'),
+      body: jsonEncode({'access_token': auth.accessToken}),
+      headers: {'Content-Type': 'application/json'},
+    );
+    if (response.statusCode == 200) {
+      // Handle success
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Colors.orange.shade50,
+      body: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            TextField(
+              controller: _emailController,
+              decoration: const InputDecoration(labelText: 'Email'),
+            ),
+            const SizedBox(height: 12),
+            TextField(
+              controller: _passwordController,
+              obscureText: true,
+              decoration: const InputDecoration(labelText: 'Password'),
+            ),
+            const SizedBox(height: 24),
+            ElevatedButton(
+              onPressed: _login,
+              child: const Text('Login'),
+            ),
+            const SizedBox(height: 16),
+            OutlinedButton(
+              onPressed: _googleLogin,
+              child: const Text('Sign in with Google'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/frontend/lib/main.dart
+++ b/frontend/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'login_page.dart';
 
 void main() {
   runApp(const MyApp());
@@ -11,10 +12,8 @@ class MyApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return MaterialApp(
       title: 'Couple App',
-      theme: ThemeData(primarySwatch: Colors.blue),
-      home: const Scaffold(
-        body: Center(child: Text('Couple App')),
-      ),
+      theme: ThemeData(primarySwatch: Colors.deepOrange),
+      home: const LoginPage(),
     );
   }
 }

--- a/frontend/pubspec.yaml
+++ b/frontend/pubspec.yaml
@@ -9,6 +9,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  http: ^0.13.5
+  google_sign_in: ^5.4.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- set up Django auth with dj-rest-auth and JWT
- configure Google OAuth login endpoint
- add Flutter login screen with warm colors
- add http and google_sign_in Flutter dependencies

## Testing
- `python -m py_compile $(git ls-files 'backend/**/*.py')`
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_b_686a7972f6848329b871046f22557cb4